### PR TITLE
Reset DIV2 with other flags when setting waveform

### DIFF
--- a/AD9833.cpp
+++ b/AD9833.cpp
@@ -133,7 +133,7 @@ void AD9833::setWave(uint8_t waveform)
   _waveform = waveform;
 
   //  clear bits in control register
-  _control &= ~(AD9833_SLEEP1 | AD9833_SLEEP12 | AD9833_OPBITEN | AD9833_MODE);
+  _control &= ~(AD9833_SLEEP1 | AD9833_SLEEP12 | AD9833_OPBITEN | AD9833_MODE | AD9833_DIV2);
 
   //  set bits in control register
   switch(_waveform)


### PR DESCRIPTION
@RobTillaart - I hope you're open to PRs. I think the DIV2 bit should be reset in the control word when the frequency is set, so that you can switch from SQUARE1 to SQUARE2. 